### PR TITLE
Update getch.py to be Mac compatible, take 2

### DIFF
--- a/core/utils/getch.py
+++ b/core/utils/getch.py
@@ -1,13 +1,14 @@
+from sys import platform
+
+
 class _Getch:
 	"""Gets a single character from standard input.  Does not echo to the
 screen."""
 
 	def __init__(self):
-		try:
+		if platform == "win32":
 			self.impl = _GetchWindows()
-		except ModuleNotFoundError:
-			self.impl = _GetchUnix()
-		except ImportError:
+		else:
 			self.impl = _GetchUnix()
 
 	def __call__(self):

--- a/settings.py
+++ b/settings.py
@@ -1,11 +1,7 @@
-import logging
-import os
+from os import getcwd
 from sys import platform
 
 DEBUG = True
-
-logging.basicConfig(level=logging.DEBUG,
-					format='[%(levelname)s] (%(threadName)-10s) %(message)s')
 
 if platform == "win32":
 	ANSI_COLORS = {
@@ -39,7 +35,7 @@ TILESIZE = 64
 GRIDWIDTH = WIDTH / TILESIZE
 GRIDHEIGHT = HEIGHT / TILESIZE
 
-GAMEDIR = os.getcwd()
+GAMEDIR = getcwd()
 
 # Player settings
 PLAYERSPEED = 350


### PR DESCRIPTION
Changelog:
 - Making use of if statements an sys.platform to check whether or not to use Windows library
 - Updated settings.py to remove unused logging library and import only part of os we use; getcwd()
Signed-off-by: Melle Bosboom <jubiman@users.noreply.github.com>